### PR TITLE
 Typescript, API simplification, and dev updates 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.rpt2_cache/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "tabWidth": 4,
+  "printWidth": 120
+}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can pass a standardized set of options to each API:
 | Parameter | Type | Description | Default | Required?
 |--------|--------|--------|--------|--------|
 | appId | String | The application ID supplied by the network |  | Yes |
-| apiVersion | Number | The api version to use | Latest API version  | No |
+| version | String | The api version to use |   | Yes |
 | apiKey | String | The application key used to access the network's API |  | No |
 | apiSecret | String | The application secret used to access the network's API |  | No |
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
             },
             plugins: [
                 require('rollup-plugin-node-resolve')(),
-                require('rollup-plugin-typescript')(),
+                require('rollup-plugin-typescript2')(),
                 require('rollup-plugin-commonjs')()
             ]
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,15 @@
       "integrity": "sha512-GzdHjq3t3eGLMv92Al90Iq+EoLL+86mPfQhuglbBFO7HiLdC/rkt+zrzJJumAiBF6nsrBWhou22rPW663AAyFw==",
       "dev": true
     },
+    "@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -172,7 +181,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
       "requires": {
         "arr-flatten": "^1.0.1"
       }
@@ -180,8 +188,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -219,8 +226,7 @@
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
@@ -446,7 +452,6 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
       "requires": {
         "expand-range": "^1.8.1",
         "preserve": "^0.2.0",
@@ -1280,8 +1285,7 @@
     "estree-walker": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
-      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
-      "dev": true
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig=="
     },
     "esutils": {
       "version": "2.0.2",
@@ -1343,7 +1347,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
       "requires": {
         "is-posix-bracket": "^0.1.0"
       }
@@ -1352,7 +1355,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
       "requires": {
         "fill-range": "^2.1.0"
       }
@@ -1419,7 +1421,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -1458,14 +1459,12 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fill-range": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-      "dev": true,
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
@@ -1489,14 +1488,12 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
       "requires": {
         "for-in": "^1.0.1"
       }
@@ -1517,6 +1514,16 @@
       "dev": true,
       "requires": {
         "null-check": "^1.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -2090,7 +2097,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
       "requires": {
         "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
@@ -2100,7 +2106,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2121,8 +2126,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growl": {
       "version": "1.10.5",
@@ -2421,8 +2425,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -2455,14 +2458,12 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
       "requires": {
         "is-primitive": "^2.0.0"
       }
@@ -2470,20 +2471,17 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -2498,7 +2496,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -2547,14 +2544,12 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-promise": {
       "version": "2.1.0",
@@ -2577,8 +2572,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "3.0.3",
@@ -2599,7 +2593,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       }
@@ -2625,6 +2618,14 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "just-extend": {
       "version": "3.0.0",
@@ -3414,7 +3415,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -3516,8 +3516,7 @@
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "dev": true
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -3529,7 +3528,6 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
       "requires": {
         "arr-diff": "^2.0.0",
         "array-unique": "^0.2.1",
@@ -3781,7 +3779,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -3852,7 +3849,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
       "requires": {
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
@@ -3950,7 +3946,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
       "requires": {
         "glob-base": "^0.3.0",
         "is-dotfile": "^1.0.0",
@@ -4015,8 +4010,7 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -4092,8 +4086,7 @@
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -4117,7 +4110,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
-      "dev": true,
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -4127,14 +4119,12 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -4230,7 +4220,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
       }
@@ -4254,20 +4243,17 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -4289,7 +4275,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
       }
@@ -4378,21 +4363,21 @@
         }
       }
     },
-    "rollup-plugin-typescript": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript/-/rollup-plugin-typescript-1.0.0.tgz",
-      "integrity": "sha512-d2KDNMJXgaaB//dDGd/YmyMiopt1Pz965Iu3zmEoL08YqNcKRBz26uHqqc47rFGfrJV5kFqifC9IYlh6dpSCLg==",
-      "dev": true,
+    "rollup-plugin-typescript2": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.18.0.tgz",
+      "integrity": "sha512-AL7LJl31bYO/x8zO1fuE7ACn/2nDs9DVYL3qjiWSYg5LC4EV/iKuCL4Fm6pjzEqCB4fFIMXoUuGUf5R+BLNKSg==",
       "requires": {
-        "resolve": "^1.8.1",
-        "rollup-pluginutils": "^2.3.1"
+        "fs-extra": "7.0.0",
+        "resolve": "1.8.1",
+        "rollup-pluginutils": "2.3.3",
+        "tslib": "1.9.3"
       }
     },
     "rollup-pluginutils": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",
       "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
-      "dev": true,
       "requires": {
         "estree-walker": "^0.5.2",
         "micromatch": "^2.3.11"
@@ -5008,8 +4993,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
       "version": "5.11.0",
@@ -5160,6 +5144,11 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,292 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        }
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -582,6 +868,125 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "chokidar": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
+      },
+      "dependencies": {
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -3060,355 +3465,12 @@
       }
     },
     "karma-rollup-preprocessor": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-6.1.0.tgz",
-      "integrity": "sha512-/sps47osPwmtHpiod3lQWvhJXA1g0aSij8O4VyP2lv5PFEIB7Nft2k8yCSVGdO+dbvmpfXJ85cpqklUah4VGhw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-6.1.1.tgz",
+      "integrity": "sha512-irtnV8Q+nGo7WllPht5Hc7LOURlgoPOie9cAsZqpKAbO7v1NvboH3M4ztJiL41+SqQ4FVv1NP37/zoYFRYhpcg==",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.0"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-          "dev": true,
-          "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
-          }
-        },
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "chokidar": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
-          "dev": true,
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.0",
-            "braces": "^2.3.0",
-            "fsevents": "^1.2.2",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "lodash.debounce": "^4.0.8",
-            "normalize-path": "^2.1.1",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0",
-            "upath": "^1.0.5"
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        }
       }
     },
     "kind-of": {
@@ -4323,9 +4385,9 @@
       }
     },
     "rollup": {
-      "version": "0.67.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.67.0.tgz",
-      "integrity": "sha512-p34buXxArhwv9ieTdHvdhdo65Cbig68s/Z8llbZuiX5e+3zCqnBF02Ck9IH0tECrmvvrJVMws32Ry84hTnS1Tw==",
+      "version": "0.67.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.67.3.tgz",
+      "integrity": "sha512-TyNQCz97rKuVVbsKUTXfwIjV7UljWyTVd7cTMuE+aqlQ7WJslkYF5QaYGjMLR2BlQtUOO5CAxSVnpQ55iYp5jg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
@@ -5059,9 +5121,9 @@
       }
     },
     "tslint-config-prettier": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz",
-      "integrity": "sha512-06CgrHJxJmNYVgsmeMoa1KXzQRoOdvfkqnJth6XUkNeOz707qxN0WfxfhYwhL5kXHHbYJRby2bqAPKwThlZPhw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.17.0.tgz",
+      "integrity": "sha512-NKWNkThwqE4Snn4Cm6SZB7lV5RMDDFsBwz6fWUkTxOKGjMx8ycOHnjIbhn7dZd5XmssW3CwqUjlANR6EhP9YQw==",
       "dev": true
     },
     "tsutils": {
@@ -5099,9 +5161,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
+      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==",
       "dev": true
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -49,16 +49,16 @@
     "karma": "^3.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
-    "karma-rollup-preprocessor": "^6.0.1",
+    "karma-rollup-preprocessor": "^6.1.1",
     "mocha": "^5.2.0",
     "mock-raf": "^1.0.0",
-    "rollup": "^0.67.0",
+    "rollup": "^0.67.3",
     "rollup-plugin-commonjs": "^9.1.6",
     "rollup-plugin-node-resolve": "^3.4.0",
     "sinon": "^7.1.1",
     "tslint": "^5.11.0",
-    "tslint-config-prettier": "^1.15.0",
-    "typescript": "^3.0.3"
+    "tslint-config-prettier": "^1.17.0",
+    "typescript": "^3.2.1"
   },
   "dependencies": {
     "@types/facebook-js-sdk": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "vine api"
   ],
   "main": "dist/index.js",
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "karma start karma.conf.js && npm run lint",
     "test-server": "karma start karma.conf.js --single-run=false",
@@ -42,6 +42,7 @@
     "lint": "tslint src/**/*"
   },
   "devDependencies": {
+    "@types/oauth": "^0.9.1",
     "banner-cli": "0.11.1",
     "chai": "^4.1.2",
     "eslint": "^5.5.0",
@@ -54,7 +55,6 @@
     "rollup": "^0.67.0",
     "rollup-plugin-commonjs": "^9.1.6",
     "rollup-plugin-node-resolve": "^3.4.0",
-    "rollup-plugin-typescript": "^1.0.0",
     "sinon": "^7.1.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
@@ -63,6 +63,7 @@
   "dependencies": {
     "@types/facebook-js-sdk": "^3.1.0",
     "dynamic-import": "^0.1.0",
-    "oauth": "^0.9.14"
+    "oauth": "^0.9.14",
+    "rollup-plugin-typescript2": "^0.18.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import typescript from 'rollup-plugin-typescript';
+import typescript from 'rollup-plugin-typescript2';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,31 +2,17 @@ import typescript from 'rollup-plugin-typescript2';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 
-const filenames = [
-    'facebook',
-    'instagram',
-    'tumblr',
-    'twitter',
-    'vine',
-    'index'
-];
+const filenames = ['facebook', 'instagram', 'tumblr', 'twitter', 'vine', 'index'];
 
-const exports = filenames.map((name) => {
-   return {
-       input: `src/${name}.ts`,
-       output: {
-           format: 'esm',
-           file: `dist/${name}.js`
-       },
-       plugins: [
-           resolve(),
-           typescript(),
-           commonjs()
-       ],
-       watch: {
-           include: 'src/**'
-       }
-   }
+const exports = filenames.map(name => {
+    return {
+        input: `src/${name}.ts`,
+        output: {
+            format: 'esm',
+            file: `dist/${name}.js`
+        },
+        plugins: [resolve(), typescript(), commonjs()]
+    };
 });
 
-export default exports
+export default exports;

--- a/src/base-api.ts
+++ b/src/base-api.ts
@@ -1,37 +1,57 @@
 import { script } from 'dynamic-import';
 
-export interface ApiInitOptions {
-    apiVersion?: string | number;
+export interface InitOptions {
+    version?: string;
     apiKey?: string;
     apiSecret?: string;
-    callbackUrl?: string
+    apiVersion?: string | number; // TODO: Deprecated, remove in next major version
 }
 
-export interface ApiUserAccessCredentials {
-    accessToken: string,
-    accessTokenSecret: string,
-    userId?: string,
-    expiresAt?: Date
+export interface UserAccessCredentials {
+    accessToken: string;
+    accessTokenSecret?: string;
+    userId?: string;
+    expiresAt?: number;
 }
 
-export interface ApiLoginOptions {
-    permissions?: string[],
-    scope?: string
+export interface LoginOptions {
+    permissions?: Permission[];
+}
+
+export type Permission =
+    | 'createPosts'
+    | 'readPosts'
+    | 'updatePosts'
+    | 'deletePosts'
+    | 'readProfile'
+    | 'readFriendProfiles';
+
+export interface PermissionsMap {
+    createPosts: Array<'publish_actions'>;
+    readPosts: Array<'user_posts'>;
+    updatePosts: Array<'publish_actions'>;
+    deletePosts: Array<'publish_actions'>;
+    readProfile: Array<'public_profile' | 'user_about_me' | 'user_birthday' | 'user_location' | 'user_work_history'>;
+    readFriendProfiles: Array<'user_friends'>;
 }
 
 const loadedScripts: string[] = [];
 
 export default abstract class BaseApi {
-    
-    protected options: ApiInitOptions;
+    protected options: InitOptions;
     private script?: string;
-    private loadApiListenerPromiseMap: Promise<void>;
+    private loadApiListenerPromiseMap?: Promise<void>;
 
-    constructor (options: ApiInitOptions) {
+    constructor(options: InitOptions = {}) {
+        if (options.apiVersion) {
+            console.warn(`"apiVersion" has been deprecated, please use the "version" option`);
+            options.version = options.apiVersion + '';
+        }
         this.options = options;
     }
 
-    destroy () {
+    destroy() {
+        if (!this.script) return;
         const idx = loadedScripts.indexOf(this.script);
         loadedScripts.splice(idx, 1);
         if (this.script && loadedScripts.indexOf(this.script) <= -1) {
@@ -39,35 +59,33 @@ export default abstract class BaseApi {
         }
     }
 
-    async load () {
+    async load() {
         if (!this.loadApiListenerPromiseMap) {
             this.loadApiListenerPromiseMap = this.handleLoadApi(this.options);
         }
         return this.loadApiListenerPromiseMap;
     }
 
-    protected async login (options: ApiLoginOptions): Promise<ApiUserAccessCredentials> {
-       return {
-           accessToken: '',
-           accessTokenSecret: '',
-           userId: '',
-           expiresAt: null
-       }
+    protected async login(options: LoginOptions): Promise<UserAccessCredentials> {
+        return {
+            accessToken: '',
+            accessTokenSecret: '',
+            userId: '',
+            expiresAt: Date.now()
+        };
     }
 
-    protected loadScript (path: string) {
+    protected loadScript(path: string) {
         this.script = path;
         loadedScripts.push(this.script);
         return script.import(this.script);
     }
-    
 
-    protected async handleLoadApi (options: ApiInitOptions): Promise<any> {
+    protected async handleLoadApi(options: InitOptions): Promise<any> {
         return Promise.resolve();
     }
 
-    static get id () {
+    static get id() {
         return 'base-api';
     }
-    
 }

--- a/src/tumblr.ts
+++ b/src/tumblr.ts
@@ -1,42 +1,49 @@
-import BaseApi, { ApiInitOptions } from './base-api';
+import BaseApi, { InitOptions } from './base-api';
 
-interface TumblrApiOptions extends ApiInitOptions {
+declare global {
+    interface Window {
+        onTumblrReady: () => void;
+    }
+}
+
+interface TumblrApiOptions extends InitOptions {
     'base-hostname': string;
-    api_key: string
+    api_key: string;
 }
 
 export default class Tumblr extends BaseApi {
-
     protected options: TumblrApiOptions;
 
-    constructor (options: TumblrApiOptions = {
-        'base-hostname': undefined,
-        api_key: undefined
-    }) {
+    constructor(options: TumblrApiOptions) {
         super(options);
         if (!options['base-hostname']) {
             throw Error('Tumblr constructor needs to be passed a "base-hostname" option');
         }
         options.api_key = options.api_key || '';
+        this.options = options;
     }
 
-    static get id () {
+    static get id() {
         return 'tumblr';
     }
 
-    protected async handleLoadApi () {
+    protected async handleLoadApi() {
         const callbackMethod = 'onTumblrReady';
 
         // we're arbitrarily choosing the "/posts" endpoint to prevent getting a 404 error
         const scriptUrl =
-            '//api.tumblr.com/v2/blog/' + this.options['base-hostname'] + '/posts?' +
-            'api_key=' + this.options.api_key + '&' +
-            'callback=' + callbackMethod;
+            '//api.tumblr.com/v2/blog/' +
+            this.options['base-hostname'] +
+            '/posts?' +
+            'api_key=' +
+            this.options.api_key +
+            '&' +
+            'callback=' +
+            callbackMethod;
 
-        return new Promise((resolve) => {
+        return new Promise(resolve => {
             window[callbackMethod] = resolve;
             this.loadScript(scriptUrl);
-        })
+        });
     }
-
 }

--- a/tests/facebook-tests.js
+++ b/tests/facebook-tests.js
@@ -5,39 +5,39 @@ import _ from 'lodash';
 import chai from 'chai';
 const { assert } = chai;
 
-
-describe('Facebook', function () {
-
+describe('Facebook', function() {
     let origFB;
     let scriptImportStub;
     let loadScriptTrigger = {};
 
-    beforeEach(function () {
+    beforeEach(function() {
         origFB = window.FB;
         window.FB = {
             init: sinon.spy(),
             login: sinon.stub()
         };
         scriptImportStub = sinon.stub(script, 'import');
-        scriptImportStub.returns(new Promise((resolve) => {
-            loadScriptTrigger.resolve = resolve;
-        }));
+        scriptImportStub.returns(
+            new Promise(resolve => {
+                loadScriptTrigger.resolve = resolve;
+            })
+        );
     });
 
-    afterEach(function () {
+    afterEach(function() {
         window.FB = origFB;
         scriptImportStub.restore();
     });
 
-    it('should call script import method with the correct url to the facebook js script', function () {
-        let facebook = new Facebook();
+    it('should call script import method with the correct url to the facebook js script', function() {
+        let facebook = new Facebook({});
         facebook.load();
         assert.deepEqual(scriptImportStub.args[0], ['https://connect.facebook.net/en_US/sdk.js']);
         facebook.destroy();
     });
 
-    it('should call FB.init with xfmbl set to "true" if it hasnt been specified in options when api is loaded', function (done) {
-        let facebook = new Facebook();
+    it('should call FB.init with xfmbl set to "true" if it hasnt been specified in options when api is loaded', function(done) {
+        let facebook = new Facebook({});
         facebook.load();
         _.defer(() => {
             window.fbAsyncInit(); //trigger api load
@@ -48,21 +48,10 @@ describe('Facebook', function () {
         });
     });
 
-    it('should call FB.init with latest version if there is none specified when api is loaded', function (done) {
-        let facebook = new Facebook();
-        facebook.load();
-        _.defer(() => {
-            window.fbAsyncInit(); //trigger api load
-            var FBInitOptions = window.FB.init.args[0][0];
-            assert.equal(FBInitOptions.version, 'v3', 'object passed FB.init() includes version set to "v2.1"');
-            facebook.destroy();
-            done();
-        });
-    });
-
-    it('should call FB.init when "v[VERSION]" option when "apiVersion" number is specified when api is loaded', function (done) {
-        var version = 2.5;
-        let facebook = new Facebook({apiVersion: version});
+    it('should call FB.init when "v[VERSION]" option when "version" number is specified when api is loaded', function(done) {
+        var version = '2.5';
+        let facebook = new Facebook({ version });
+        debugger;
         facebook.load();
         _.defer(() => {
             window.fbAsyncInit(); //trigger api load
@@ -73,9 +62,22 @@ describe('Facebook', function () {
         });
     });
 
-    it('should call FB.init when "version" string when api is loaded', function (done) {
+    it('should call FB.init when "v[VERSION]" option when "apiVersion" number is specified when api is loaded', function(done) {
+        var version = 2.5;
+        let facebook = new Facebook({ apiVersion: version });
+        facebook.load();
+        _.defer(() => {
+            window.fbAsyncInit(); //trigger api load
+            var FBInitOptions = window.FB.init.args[0][0];
+            assert.equal(FBInitOptions.version, 'v' + version);
+            facebook.destroy();
+            done();
+        });
+    });
+
+    it('should call FB.init when "version" string when api is loaded', function(done) {
         var version = 'v3.5';
-        let facebook = new Facebook({version: version});
+        let facebook = new Facebook({ version: version });
         facebook.load();
         _.defer(() => {
             window.fbAsyncInit(); //trigger api load
@@ -86,9 +88,9 @@ describe('Facebook', function () {
         });
     });
 
-    it('should load the FB object with appId specified in options when api is loaded', function (done) {
+    it('should load the FB object with appId specified in options when api is loaded', function(done) {
         var id = 'myFacebookAppId';
-        let facebook = new Facebook({appId: id});
+        let facebook = new Facebook({ appId: id });
         facebook.load();
         _.defer(() => {
             window.fbAsyncInit(); //trigger api load
@@ -99,126 +101,133 @@ describe('Facebook', function () {
         });
     });
 
-    it('should resolve the load promise only when script import method resolves and fbAsyncInit has been triggered', function (done) {
+    it('should resolve the load promise only when script import method resolves and fbAsyncInit has been triggered', function(done) {
         var loadSpy = sinon.spy();
-        let facebook = new Facebook();
+        let facebook = new Facebook({});
         facebook.load().then(loadSpy);
         _.defer(() => {
             assert.equal(loadSpy.callCount, 0, 'load hasnt resolved because ResourceManager loadScript hasnt resolved');
             loadScriptTrigger.resolve();
-            assert.equal(loadSpy.callCount, 0, 'load still hasnt resolved after ResourceManager loadScript is resolved because fbAsyncInit hasnt been triggered');
+            assert.equal(
+                loadSpy.callCount,
+                0,
+                'load still hasnt resolved after ResourceManager loadScript is resolved because fbAsyncInit hasnt been triggered'
+            );
             window.fbAsyncInit(); // trigger api load
             _.defer(() => {
-                assert.ok(loadSpy.calledWith(window.FB), 'load is resolved with FB object when fbAsyncInit is triggered');
+                assert.ok(
+                    loadSpy.calledWith(window.FB),
+                    'load is resolved with FB object when fbAsyncInit is triggered'
+                );
                 facebook.destroy();
                 done();
             });
         });
     });
 
-    it('passing a readFriendProfiles permission into login should pass appropriate scope permissions to the FB.login', function () {
+    it('passing a readFriendProfiles permission into login should pass appropriate scope permissions to the FB.login', function() {
         scriptImportStub.returns(Promise.resolve());
-        var resp = {authResponse: {}};
+        var resp = { authResponse: {} };
         window.FB.login.yields(resp);
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
-        let facebook = new Facebook();
-        return facebook.login({permissions: ['readFriendProfiles']}).then(() => {
+        let facebook = new Facebook({});
+        return facebook.login({ permissions: ['readFriendProfiles'] }).then(() => {
             assert.equal(window.FB.login.args[0][1].scope, 'user_friends');
             facebook.destroy();
         });
     });
 
-    it('passing a deletePosts permission into login should pass appropriate scope permissions to the FB.login', function () {
+    it('passing a deletePosts permission into login should pass appropriate scope permissions to the FB.login', function() {
         scriptImportStub.returns(Promise.resolve());
-        var resp = {authResponse: {}};
+        var resp = { authResponse: {} };
         window.FB.login.yields(resp);
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
-        let facebook = new Facebook();
-        return facebook.login({permissions: ['deletePosts']}).then(() => {
+        let facebook = new Facebook({});
+        return facebook.login({ permissions: ['deletePosts'] }).then(() => {
             assert.equal(window.FB.login.args[0][1].scope, 'publish_actions');
             facebook.destroy();
         });
     });
 
-    it('passing a updatePosts permission into login should pass appropriate scope permissions to the FB.login', function () {
+    it('passing a updatePosts permission into login should pass appropriate scope permissions to the FB.login', function() {
         scriptImportStub.returns(Promise.resolve());
-        var resp = {authResponse: {}};
+        var resp = { authResponse: {} };
         window.FB.login.yields(resp);
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
-        let facebook = new Facebook();
-        return facebook.login({permissions: ['updatePosts']}).then(() => {
+        let facebook = new Facebook({});
+        return facebook.login({ permissions: ['updatePosts'] }).then(() => {
             assert.equal(window.FB.login.args[0][1].scope, 'publish_actions');
             facebook.destroy();
         });
     });
 
-    it('passing a readPosts permission into login should pass appropriate scope permissions to the FB.login', function () {
+    it('passing a readPosts permission into login should pass appropriate scope permissions to the FB.login', function() {
         scriptImportStub.returns(Promise.resolve());
-        var resp = {authResponse: {}};
+        var resp = { authResponse: {} };
         window.FB.login.yields(resp);
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
-        let facebook = new Facebook();
-        return facebook.login({permissions: ['readPosts']}).then(() => {
+        let facebook = new Facebook({});
+        return facebook.login({ permissions: ['readPosts'] }).then(() => {
             assert.equal(window.FB.login.args[0][1].scope, 'user_posts');
             facebook.destroy();
         });
     });
 
-    it('passing a createPosts permission into login should pass appropriate scope permissions to the FB.login', function () {
+    it('passing a createPosts permission into login should pass appropriate scope permissions to the FB.login', function() {
         scriptImportStub.returns(Promise.resolve());
-        var resp = {authResponse: {}};
+        var resp = { authResponse: {} };
         window.FB.login.yields(resp);
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
-        let facebook = new Facebook();
-        return facebook.login({permissions: ['createPosts']}).then(() => {
+        let facebook = new Facebook({});
+        return facebook.login({ permissions: ['createPosts'] }).then(() => {
             assert.equal(window.FB.login.args[0][1].scope, 'publish_actions');
             facebook.destroy();
         });
     });
 
-    it('passing a readProfile permission into login should pass appropriate scope permission to the FB.login', function () {
+    it('passing a readProfile permission into login should pass appropriate scope permission to the FB.login', function() {
         scriptImportStub.returns(Promise.resolve());
-        var resp = {authResponse: {}};
+        var resp = { authResponse: {} };
         window.FB.login.yields(resp);
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
-        let facebook = new Facebook();
-        return facebook.login({permissions: ['readProfile']}).then(() => {
+        let facebook = new Facebook({});
+        return facebook.login({ permissions: ['readProfile'] }).then(() => {
             let str = window.FB.login.args[0][1].scope.split(',');
             assert.ok(str.indexOf('public_profile') > -1);
             assert.ok(str.indexOf('user_about_me') > -1);
@@ -229,47 +238,47 @@ describe('Facebook', function () {
         });
     });
 
-    it('multiple permissions passed into login should be converted to comma-seperated values to the FB.login', function () {
+    it('multiple permissions passed into login should be converted to comma-seperated values to the FB.login', function() {
         scriptImportStub.returns(Promise.resolve());
-        var resp = {authResponse: {}};
+        var resp = { authResponse: {} };
         window.FB.login.yields(resp);
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
         // choose multiple permissions that would match different permissions
         var testPermissions = ['createPosts', 'readPosts'];
-        let facebook = new Facebook();
-        return facebook.login({permissions: testPermissions}).then(() => {
+        let facebook = new Facebook({});
+        return facebook.login({ permissions: testPermissions }).then(() => {
             assert.equal(window.FB.login.args[0][1].scope, 'publish_actions,user_posts');
             facebook.destroy();
         });
     });
 
-    it('multiple permissions with the same mapped value passed into login should only return the mapped value once in the scope passed to FB.login', function () {
+    it('multiple permissions with the same mapped value passed into login should only return the mapped value once in the scope passed to FB.login', function() {
         scriptImportStub.returns(Promise.resolve());
-        var resp = {authResponse: {}};
+        var resp = { authResponse: {} };
         window.FB.login.yields(resp);
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
         // choose multiple permissions with same mapped value
         var testPermissions = ['createPosts', 'updatePosts'];
-        let facebook = new Facebook();
-        return facebook.login({permissions: testPermissions}).then(() => {
+        let facebook = new Facebook({});
+        return facebook.login({ permissions: testPermissions }).then(() => {
             assert.equal(window.FB.login.args[0][1].scope, 'publish_actions');
             facebook.destroy();
         });
     });
 
-    it('should resolve login promise with appropriate object when a authResponse exists in the FB.login callback', function () {
+    it('should resolve login promise with appropriate object when a authResponse exists in the FB.login callback', function() {
         scriptImportStub.returns(Promise.resolve());
         var resp = {
             authResponse: {
@@ -282,31 +291,31 @@ describe('Facebook', function () {
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
-        let facebook = new Facebook();
-        return facebook.login().then((assertResp) => {
+        let facebook = new Facebook({});
+        return facebook.login().then(assertResp => {
             assert.equal(assertResp.accessToken, resp.authResponse.accessToken);
             assert.equal(assertResp.userId, resp.authResponse.userID);
             assert.equal(assertResp.expiresAt, resp.authResponse.expiresIn);
             facebook.destroy();
-        })
+        });
     });
 
-    it('should resolve login with an empty object when an authResponse object does not exist in the FB.login callback', function (done) {
+    it('should resolve login with an empty object when an authResponse object does not exist in the FB.login callback', function(done) {
         scriptImportStub.returns(Promise.resolve());
         window.FB.login.yields({});
         // ensure fbAsyncInit is called immediately
         Object.defineProperty(window, 'fbAsyncInit', {
             configurable: true,
-            set: function (func) {
+            set: function(func) {
                 func();
             }
         });
         var resolveSpy = sinon.spy();
-        let facebook = new Facebook();
+        let facebook = new Facebook({});
         facebook.login().then(resolveSpy);
         _.defer(() => {
             var firstArg = resolveSpy.args[0][0];
@@ -314,14 +323,14 @@ describe('Facebook', function () {
             assert.ok(_.isEmpty(firstArg));
             facebook.destroy();
             done();
-        })
+        });
     });
 
-    it('should call script unload method only when there are no other instances that exist', function () {
+    it('should call script unload method only when there are no other instances that exist', function() {
         scriptImportStub.returns(Promise.resolve());
         let scriptUnloadStub = sinon.stub(script, 'unload');
-        let firstFacebookInstance = new Facebook();
-        let secondFacebookInstance = new Facebook();
+        let firstFacebookInstance = new Facebook({});
+        let secondFacebookInstance = new Facebook({});
         firstFacebookInstance.load();
         secondFacebookInstance.load();
         firstFacebookInstance.destroy();
@@ -331,4 +340,3 @@ describe('Facebook', function () {
         scriptUnloadStub.restore();
     });
 });
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "target": "es6",
     "module": "esnext",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": false
   },
   "include": [
     "src/**/*"

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,7 @@
       true,
       "single"
     ],
+    "no-console": [true, "log", "error"],
     "ordered-imports": false,
     "indent": [true, "spaces", 4],
     "max-line-length": [true, 120]


### PR DESCRIPTION
* Use more type checking and types
* Support init `version` instead of `apiVersion` for simplicity
* Use rollup-plugin-typescript2 to ensure d.ts files are distibuted with package releases
* Add prettier
* Fix strictness of TSLint
* Upgrade devDeps
* Only watch files when explicitly set in run commands